### PR TITLE
Enterprise fix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ NOTICE_FILE=NOTICE
 GOBUILD_FLAGS=-i -ldflags "-X $(BEAT_PATH)/vendor/github.com/elastic/beats/libbeat/version.buildTime=$(NOW) -X $(BEAT_PATH)/vendor/github.com/elastic/beats/libbeat/version.commit=$(COMMIT_ID)"
 GOX_OS=linux darwin windows ## @Building List of all OS to be supported by "make crosscompile".
 GOX_FLAGS=-arch="arm64 amd64"
-EXES=gcsbeat-darwin-amd64 gcsbeat-linux-amd64 gcsbeat-linux-arm64 gcsbeat-windows-amd64.exe
+EXES=githubbeat-darwin-amd64 githubbeat-linux-amd64 githubbeat-linux-arm64 githubbeat-windows-amd64.exe
 RELEASE_TEMPLATE_DIR=${BUILD_DIR}/releases/template
 
 # Path to the libbeat Makefile

--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,11 @@ ES_BEATS?=./vendor/github.com/elastic/beats
 GOPACKAGES=$(shell glide novendor)
 PREFIX?=.
 NOTICE_FILE=NOTICE
+GOBUILD_FLAGS=-i -ldflags "-X $(BEAT_PATH)/vendor/github.com/elastic/beats/libbeat/version.buildTime=$(NOW) -X $(BEAT_PATH)/vendor/github.com/elastic/beats/libbeat/version.commit=$(COMMIT_ID)"
+GOX_OS=linux darwin windows ## @Building List of all OS to be supported by "make crosscompile".
+GOX_FLAGS=-arch="arm64 amd64"
+EXES=gcsbeat-darwin-amd64 gcsbeat-linux-amd64 gcsbeat-linux-arm64 gcsbeat-windows-amd64.exe
+RELEASE_TEMPLATE_DIR=${BUILD_DIR}/releases/template
 
 # Path to the libbeat Makefile
 -include $(ES_BEATS)/libbeat/scripts/Makefile
@@ -24,21 +29,6 @@ copy-vendor:
 	cp -R ${BEAT_GOPATH}/src/github.com/elastic/beats vendor/github.com/elastic/
 	rm -rf vendor/github.com/elastic/beats/.git
 
-.PHONY: git-init
-git-init:
-	git init
-	git add README.md CONTRIBUTING.md
-	git commit -m "Initial commit"
-	git add LICENSE
-	git commit -m "Add the LICENSE"
-	git add .gitignore
-	git commit -m "Add git settings"
-	git add .
-	git reset -- .travis.yml
-	git commit -m "Add githubbeat"
-	git add .travis.yml
-	git commit -m "Add Travis CI"
-
 # This is called by the beats packer before building starts
 .PHONY: before-build
 before-build:
@@ -46,3 +36,29 @@ before-build:
 # Collects all dependencies and then calls update
 .PHONY: collect
 collect:
+
+.PHONY: pre-commit
+pre-commit: fmt clean update test
+
+# Generates release archives without needing Docker
+.PHONY: release
+release: $(EXES)
+
+$(EXES): crosscompile release-template
+	@echo "Generating release: " $@
+	
+	mkdir -p ${BUILD_DIR}/releases/$@
+	cp -r ${RELEASE_TEMPLATE_DIR}/. ${BUILD_DIR}/releases/$@
+	cp ${BUILD_DIR}/bin/$@ ${BUILD_DIR}/releases/$@/${BEAT_NAME}$(suffix $@)
+	
+	tar -zcvf ${BUILD_DIR}/releases/$@.tar.gz -C ${BUILD_DIR}/releases $@
+
+.PHONY: release-template
+release-template: update
+	mkdir -p ${RELEASE_TEMPLATE_DIR}
+	
+	cp {${BEAT_NAME}.yml,${BEAT_NAME}.reference.yml} ${RELEASE_TEMPLATE_DIR}
+	cp {README.md,NOTICE,LICENSE,fields.yml} ${RELEASE_TEMPLATE_DIR}
+
+	cp -r _meta/kibana ${RELEASE_TEMPLATE_DIR}/dashboards
+

--- a/_meta/beat.yml
+++ b/_meta/beat.yml
@@ -21,11 +21,13 @@ githubbeat:
   access_token: ""
 
   # Enterprise attributes allow special functions for those running GitHub enterprise.
-  
+
   # The base URL of the API.
-  # Leave this blank if you want to connect to GitHub.com
+  # Leave this blank if you want to connect to the public GitHub.com API
+  # This URL should always end with a trailing /
+  # Some enterprise users have reported their URL to be like xxx.yyy.com/api/v3/
   enterprise.base_url: ""
-  # The upload URL of the API, typically this is the same as the base_url. 
+  # The upload URL of the API, typically this is the same as the base_url.
   # Leave this blank if you want to connect to GitHub.com
   enterprise.upload_url: ""
 
@@ -91,4 +93,3 @@ githubbeat:
   issues.sort: "created"
   # The direction of the sort, either "asc" or "desc"
   issues.direction: "desc"
-

--- a/_meta/beat.yml
+++ b/_meta/beat.yml
@@ -29,6 +29,10 @@ githubbeat:
   # Leave this blank if you want to connect to GitHub.com
   enterprise.upload_url: ""
 
+  # Whether or not to log HTTP reqests to standard out.
+  # This is to help you debug connection issues and SHOULD NOT be used in production.
+  log_http_requests: false
+
   # The following are attributes that will make additional API calls for each repository.
   # The `enabled` property authorizes the extra API call(s).
   # If the attribute is a list it will automatically include a count of the elements in the list.

--- a/beater/githubbeat.go
+++ b/beater/githubbeat.go
@@ -115,6 +115,12 @@ func newGithubClient(config config.Config) (*github.Client, error) {
 		client.UploadURL = uploadUrl
 	}
 
+	// Test connection
+	ctx := context.Background()
+	if _, _, err := client.Repositories.List(ctx, "", nil); err != nil {
+		return nil, err
+	}
+
 	return client, nil
 }
 
@@ -131,13 +137,7 @@ func setupClient(accessToken string) (*github.Client, error) {
 		&oauth2.Token{AccessToken: accessToken},
 	)
 
-	client := github.NewClient(oauth2.NewClient(ctx, ts))
-
-	if _, _, err := client.Repositories.List(ctx, "", nil); err != nil {
-		return nil, err
-	}
-
-	return client, nil
+	return github.NewClient(oauth2.NewClient(ctx, ts)), nil
 }
 
 func (bt *Githubbeat) collectOrgsEvents(ctx context.Context, orgs []string) {

--- a/beater/requestlogger.go
+++ b/beater/requestlogger.go
@@ -1,0 +1,40 @@
+package beater
+
+import (
+	"log"
+	"net/http"
+	"net/http/httputil"
+)
+
+// loggingRoundTripper provides a way to dump HTTP requests/responses to stdout.
+// WARNING: this will include credentials so don't use it in production!
+type loggingRoundTripper struct {
+	Transport http.RoundTripper
+}
+
+func (rt loggingRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	if requestText, derr := httputil.DumpRequestOut(req, true); derr == nil {
+		log.Println("HTTP Request:", string(requestText))
+	}
+
+	log.Println("Executing HTTP Request")
+	resp, err := rt.Transport.RoundTrip(req)
+
+	if responseText, derr := httputil.DumpResponse(resp, true); derr == nil {
+		log.Println("Got HTTP Response:", string(responseText))
+	}
+
+	return resp, err
+}
+
+func LogClientHttpRequests(client *http.Client) {
+	parent := client.Transport
+	
+	if parent == nil {
+		parent = http.DefaultTransport
+	}
+
+	log.Println("Client transport:", parent)
+	rt := loggingRoundTripper{parent}
+	client.Transport = rt
+}

--- a/beater/requestlogger.go
+++ b/beater/requestlogger.go
@@ -29,7 +29,7 @@ func (rt loggingRoundTripper) RoundTrip(req *http.Request) (*http.Response, erro
 
 func LogClientHttpRequests(client *http.Client) {
 	parent := client.Transport
-	
+
 	if parent == nil {
 		parent = http.DefaultTransport
 	}

--- a/config/config.go
+++ b/config/config.go
@@ -26,6 +26,9 @@ type Config struct {
 	Downloads     PageableListConfig `config:"downloads"`
 	Issues        IssuesConfig       `config:"issues"`
 	Enterprise    EnterpriseConfig   `config:"enterprise"`
+
+	// Debugging options
+	LogHttp       bool               `config:"log_http_requests"`
 }
 
 // ListConfig has configuration for metrics that have list outputs
@@ -102,4 +105,5 @@ var DefaultConfig = Config{
 	Participation: ExtendedConfig{true},
 	Downloads:     PageableListConfig{true, false, -1},
 	Issues:        IssuesConfig{true, true, -1, "open", []string{}, "created", "desc"},
+	LogHttp:       false,
 }

--- a/config/config.go
+++ b/config/config.go
@@ -28,7 +28,7 @@ type Config struct {
 	Enterprise    EnterpriseConfig   `config:"enterprise"`
 
 	// Debugging options
-	LogHttp       bool               `config:"log_http_requests"`
+	LogHttp bool `config:"log_http_requests"`
 }
 
 // ListConfig has configuration for metrics that have list outputs

--- a/githubbeat.reference.yml
+++ b/githubbeat.reference.yml
@@ -21,11 +21,13 @@ githubbeat:
   access_token: ""
 
   # Enterprise attributes allow special functions for those running GitHub enterprise.
-  
+
   # The base URL of the API.
-  # Leave this blank if you want to connect to GitHub.com
+  # Leave this blank if you want to connect to the public GitHub.com API
+  # This URL should always end with a trailing /
+  # Some enterprise users have reported their URL to be like xxx.yyy.com/api/v3/
   enterprise.base_url: ""
-  # The upload URL of the API, typically this is the same as the base_url. 
+  # The upload URL of the API, typically this is the same as the base_url.
   # Leave this blank if you want to connect to GitHub.com
   enterprise.upload_url: ""
 
@@ -91,7 +93,6 @@ githubbeat:
   issues.sort: "created"
   # The direction of the sort, either "asc" or "desc"
   issues.direction: "desc"
-
 
 #================================ General ======================================
 

--- a/githubbeat.reference.yml
+++ b/githubbeat.reference.yml
@@ -29,6 +29,10 @@ githubbeat:
   # Leave this blank if you want to connect to GitHub.com
   enterprise.upload_url: ""
 
+  # Whether or not to log HTTP reqests to standard out.
+  # This is to help you debug connection issues and SHOULD NOT be used in production.
+  log_http_requests: false
+
   # The following are attributes that will make additional API calls for each repository.
   # The `enabled` property authorizes the extra API call(s).
   # If the attribute is a list it will automatically include a count of the elements in the list.

--- a/githubbeat.yml
+++ b/githubbeat.yml
@@ -29,6 +29,10 @@ githubbeat:
   # Leave this blank if you want to connect to GitHub.com
   enterprise.upload_url: ""
 
+  # Whether or not to log HTTP reqests to standard out.
+  # This is to help you debug connection issues and SHOULD NOT be used in production.
+  log_http_requests: false
+
   # The following are attributes that will make additional API calls for each repository.
   # The `enabled` property authorizes the extra API call(s).
   # If the attribute is a list it will automatically include a count of the elements in the list.

--- a/githubbeat.yml
+++ b/githubbeat.yml
@@ -21,11 +21,13 @@ githubbeat:
   access_token: ""
 
   # Enterprise attributes allow special functions for those running GitHub enterprise.
-  
+
   # The base URL of the API.
-  # Leave this blank if you want to connect to GitHub.com
+  # Leave this blank if you want to connect to the public GitHub.com API
+  # This URL should always end with a trailing /
+  # Some enterprise users have reported their URL to be like xxx.yyy.com/api/v3/
   enterprise.base_url: ""
-  # The upload URL of the API, typically this is the same as the base_url. 
+  # The upload URL of the API, typically this is the same as the base_url.
   # Leave this blank if you want to connect to GitHub.com
   enterprise.upload_url: ""
 
@@ -91,7 +93,6 @@ githubbeat:
   issues.sort: "created"
   # The direction of the sort, either "asc" or "desc"
   issues.direction: "desc"
-
 
 #================================ General =====================================
 


### PR DESCRIPTION
If you entered an auth token with an enterprise URL githubbeat would try to verify the token by polling a URL before the custom enterprise URL was set causing the app to crash.

This moves the check to after any custom URLs are set.