### PR TITLE
remove timestamp causing double JSON serialization

### DIFF
--- a/beater/githubbeat.go
+++ b/beater/githubbeat.go
@@ -226,7 +226,6 @@ func (bt *Githubbeat) newFullRepoEvent(ctx context.Context, repo *github.Reposit
 	data := extractRepoData(repo)
 
 	// beat metadata
-	data["@timestamp"] = common.Time(time.Now())
 	data["type"] = "githubbeat"
 
 	addIf := func(key string, c collector) {


### PR DESCRIPTION
For some reason having this extra timestamp here caused a double serialization of the `@timestamp` field in the output. We were getting two because beats originally wanted you to set your own timestamp, but later changed the library to include it automatically as it was a required field for every event, when we upgraded the backing beats library this remained.